### PR TITLE
Make sure an array is passed to DQL.item.contains

### DIFF
--- a/eclipse/bundles/org.openntf.xsp.jakarta.nosql.driver/src/org/openntf/xsp/jakarta/nosql/communication/driver/impl/QueryConverter.java
+++ b/eclipse/bundles/org.openntf.xsp.jakarta.nosql.driver/src/org/openntf/xsp/jakarta/nosql/communication/driver/impl/QueryConverter.java
@@ -20,7 +20,9 @@ import static org.eclipse.jnosql.communication.Condition.IN;
 import java.time.temporal.Temporal;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.ArrayList;
 import java.util.Set;
+import java.lang.Iterable;
 
 import org.eclipse.jnosql.communication.Condition;
 import org.eclipse.jnosql.communication.TypeReference;
@@ -148,8 +150,23 @@ public enum QueryConverter {
 			case IN:
 				if(value instanceof Number) {
 					throw new IllegalArgumentException("Unable to perform IN query on a number");
-				} else {
-					return DQL.item(name).contains(value == null ? "" : value.toString()); //$NON-NLS-1$
+                } else {
+                    List<String> valueHelper = new ArrayList<>();
+
+                    // Make sure value is valid.
+                    if (value == null) {
+                        value = "";
+                    } else if (value.getClass().isArray()) {
+                        value = Arrays.asList(value);
+                    }
+                    
+                    // If value is an Iterable, convert all entries to String.
+                    if (value instanceof Iterable) {
+                        ((Iterable<?>)value).forEach(item -> valueHelper.add(item.toString()));
+                    } else {
+                        valueHelper.add(value.toString());
+                    }
+					return DQL.item(name).contains(valueHelper.toArray(new String[valueHelper.size()])); //$NON-NLS-1$
 				}
 			case AND: {
 				List<CriteriaCondition> conditions = document.get(new TypeReference<List<CriteriaCondition>>() {});


### PR DESCRIPTION
Hey Jesse,

I had the problem that when I'm building a query and using the *in* method of the *DocumentCondition* class, the list was just right away converted to a string. That led to something like *"field contains ('[foo1, foo2, foo3]')"*  in the final query which obviously failed. I added some handling to deal with lists and arrays. However, I could not compile or test it on my machine so I'm not sure if it's working correctly. I would be glad if you could merge my pull-request if it works as expected or give me feedback what needs to be changed.

BR Michel